### PR TITLE
Store the plex version in tags.json

### DIFF
--- a/.github/workflows/create-tag-schedule.yml
+++ b/.github/workflows/create-tag-schedule.yml
@@ -6,11 +6,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  create_release:
+  create_version_number:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    
+    outputs:
+      release: steps.v_bump.outputs.release
+      hotio_version: steps.t_hotio.outputs.tag
+      intermediate: steps.v_bump.outputs.intermediate
+      intermediate_number: steps.v_release.outputs.intermediate
+      intermediate_version: steps.v_release.outputs.tag
       
     steps:
       - name: Checkout repository
@@ -84,22 +91,55 @@ jobs:
           echo "::set-output name=intermediate::${intermediate}"                          # output intermediate version number
           echo "::set-output name=tag::${{ steps.t_hotio.outputs.tag }}-${intermediate}"  # output the intermediate version
 
+  update_tags:
+    runs-on: ubuntu-latest
+    needs: create_version_number
+    if: ${{ needs.create_version_number.outputs.release == "true" && needs.create_version_number.outputs.intermediate != "true" }}
+    steps:
+      - name: Update tags.json
+        env:
+          SHA_SHORT: $(git rev-parse --short HEAD)
+          VERSION: ${{ needs.create_version_number.outputs.hotio_version }}
+        shell: bash
+        run: |
+          if [[ -f ./tags.json ]]; then
+            json=$(cat ./tags.json)
+            jq '(.version) |= "'"${VERSION//\~/-}"'"' <<< "${json}" > ./tags.json
+            json=$(cat ./tags.json)
+            jq '(.lastUpdated) |= "'"$(date -u +'%FT%T.%3NZ')"'"' <<< "${json}" > ./tags.json
+            json=$(cat ./tags.json)
+            jq '(.commit) |= "'"${SHA_SHORT}"'"' <<< "${json}" > ./tags.json
+          fi
+          
+      - name: Commit tags.json
+        uses: EndBug/add-and-commit@v8.0.2
+        with:
+          message: "update tags.json | ${{ needs.create_version_number.outputs.hotio_version }}"
+
+  create_release:
+    runs-on: ubuntu-latest
+    needs: [ update_tags, create_version_number ]
+    if: ${{ needs.create_version_number.outputs.release == "true" }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+    
       - name: Generate Release Body
-        if: ${{ steps.v_bump.outputs.release == 'true' }}
         id: body
         run: |
-          if [ "${{ steps.v_bump.outputs.intermediate }}" == "true" ]; then
-            echo "::set-output name=message::Manual update to intermediate version ${{ steps.v_release.outputs.intermediate }}. A intermediate update only includes changes made in this repository, meaning this is not a new Plex update."
+          if [ "${{ needs.create_version_number.outputs.intermediate }}" == "true" ]; then
+            echo "::set-output name=message::Manual update to intermediate version ${{ needs.create_version_number.outputs.intermediate_number }}. A intermediate update only includes changes made in this repository, meaning this is not a new Plex update."
           else
-            echo "::set-output name=message::Automatic version bump to ${{ steps.t_hotio.outputs.tag }}"
+            echo "::set-output name=message::Automatic version bump to ${{ needs.create_version_number.outputs.hotio_version }}"
           fi
 
       - name: Create Release
-        if: ${{ steps.v_bump.outputs.release == 'true' }}
         uses: softprops/action-gh-release@v0.1.14
         with:
-          tag_name: ${{ steps.v_release.outputs.tag || steps.t_hotio.outputs.tag }}
-          name: ${{ steps.v_release.outputs.tag || steps.t_hotio.outputs.tag }}
+          tag_name: ${{ needs.create_version_number.outputs.intermediate_version || needs.create_version_number.outputs.hotio_version }}
+          name: ${{ needs.create_version_number.outputs.intermediate_version || needs.create_version_number.outputs.hotio_version }}
           body: "${{ steps.body.outputs.message }}"
           draft: false
           prerelease: false

--- a/tags.json
+++ b/tags.json
@@ -1,0 +1,6 @@
+{
+  "name": "latest",
+  "version": "",
+  "commit": "",
+  "lastUpdated": ""
+}


### PR DESCRIPTION
This PR is mainly to keep the github actions going, updates tags.json whenever there is a new version of hotio/plex. 